### PR TITLE
Update build.sh to make web tokenizer work with chrome extension

### DIFF
--- a/web/build.sh
+++ b/web/build.sh
@@ -11,5 +11,5 @@ cd ..
 
 emcc --bind -o src/tokenizers_binding.js src/tokenizers_binding.cc\
   build/libtokenizers_cpp.a build/libtokenizers_c.a   build/sentencepiece/src/libsentencepiece.a\
- -O3 -s EXPORT_ES6=1 -s MODULARIZE=1 -s SINGLE_FILE=1 -s EXPORTED_RUNTIME_METHODS=FS -s ALLOW_MEMORY_GROWTH=1\
+ -O3 -s EXPORT_ES6=1 -s ERROR_ON_UNDEFINED_SYMBOLS=0 -s NO_DYNAMIC_EXECUTION=1 -s MODULARIZE=1 -s SINGLE_FILE=1 -s EXPORTED_RUNTIME_METHODS=FS -s ALLOW_MEMORY_GROWTH=1\
  -I../include


### PR DESCRIPTION
web-llm's chrome extension not working with manifest version 3 and Google will be stopping manifest version 2 in January, 2024

The chrome extension isn't working because of use of evals in code. using -s NO_DYNAMIC_EXECUTION=1 removes eval() and new Function() from generated code

refer: discussions in https://github.com/mlc-ai/web-llm/issues/214