### PR TITLE
[Web] Expose getVocabSize and idToToken to web, bump version to 0.1.3

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mlc-ai/web-tokenizers",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/web/src/tokenizers.ts
+++ b/web/src/tokenizers.ts
@@ -55,6 +55,27 @@ export class Tokenizer {
   }
 
   /**
+   * Returns the vocabulary size. Special tokens are considered.
+   *
+   * @returns Vocab size.
+   */
+  getVocabSize(): number {
+    const res = this.handle.GetVocabSize();
+    return res;
+  }
+
+  /**
+   * Convert the given id to its corresponding token if it exists. If not, return an empty string.
+   *
+   * @param id the input id.
+   * @returns The decoded string.
+   */
+  idToToken(id: number): string {
+    const res = this.handle.IdToToken(id).slice();
+    return res;
+  }
+
+  /**
    * Create a tokenizer from jsonArrayBuffer
    *
    * @param json The input array buffer that contains json text.
@@ -74,13 +95,13 @@ export class Tokenizer {
    * @returns The tokenizer
    */
   static async fromByteLevelBPE(
-      vocab: ArrayBuffer,
-      merges: ArrayBuffer,
-      addedTokens = ""
-  ) : Promise<Tokenizer> {
-      await asyncInitTokenizers();
-      return new Tokenizer(
-        binding.Tokenizer.FromBlobByteLevelBPE(vocab, merges, addedTokens));
+    vocab: ArrayBuffer,
+    merges: ArrayBuffer,
+    addedTokens = ""
+  ): Promise<Tokenizer> {
+    await asyncInitTokenizers();
+    return new Tokenizer(
+      binding.Tokenizer.FromBlobByteLevelBPE(vocab, merges, addedTokens));
   }
 
   /**
@@ -89,9 +110,9 @@ export class Tokenizer {
    * @param model The model blob.
    * @returns The tokenizer
    */
-   static async fromSentencePiece(model: ArrayBuffer) : Promise<Tokenizer> {
+  static async fromSentencePiece(model: ArrayBuffer): Promise<Tokenizer> {
     await asyncInitTokenizers();
-      return new Tokenizer(
-        binding.Tokenizer.FromBlobSentencePiece(model));
+    return new Tokenizer(
+      binding.Tokenizer.FromBlobSentencePiece(model));
   }
 }

--- a/web/src/tokenizers_binding.cc
+++ b/web/src/tokenizers_binding.cc
@@ -21,5 +21,7 @@ EMSCRIPTEN_BINDINGS(tokenizers) {
       .class_function("FromBlobByteLevelBPE", &tokenizers::Tokenizer::FromBlobByteLevelBPE)
       .class_function("FromBlobSentencePiece", &tokenizers::Tokenizer::FromBlobSentencePiece)
       .function("Encode", &tokenizers::Tokenizer::Encode)
-      .function("Decode", &tokenizers::Tokenizer::Decode);
+      .function("Decode", &tokenizers::Tokenizer::Decode)
+      .function("GetVocabSize", &tokenizers::Tokenizer::GetVocabSize)
+      .function("IdToToken", &tokenizers::Tokenizer::IdToToken);
 }

--- a/web/tests/src/index.ts
+++ b/web/tests/src/index.ts
@@ -12,12 +12,27 @@ async function testJSONTokenizer() {
   console.log("ids=" + ids)
   const decodedText = tok.decode(ids);
   console.log("decoded=" + decodedText);
+
+  const vocabSize = tok.getVocabSize();
+  console.log("vocabSize=" + vocabSize);
+
+  const tok0 = tok.idToToken(0);
+  console.log("tok0=" + tok0);
+  if (tok0 !== "!") {
+    throw Error("Expect token 0 to be !");
+  }
+
+  const tok49407 = tok.idToToken(49407);
+  console.log("tok49407=" + tok49407);
+  if (tok49407 !== "<|endoftext|>") {
+    throw Error("Expect token 49407 to be <|endoftext|>");
+  }
 }
 
 async function testLlamaTokenizer() {
   console.log("Llama Tokenizer");
   const modelBuffer = await (await
-      fetch("https://huggingface.co/hongyij/web-llm-test-model/resolve/main/tokenizer.model")
+    fetch("https://huggingface.co/hongyij/web-llm-test-model/resolve/main/tokenizer.model")
   ).arrayBuffer();
   const tok = await Tokenizer.fromSentencePiece(modelBuffer);
   const text = "What is the capital of Canada?";
@@ -25,6 +40,12 @@ async function testLlamaTokenizer() {
   console.log("ids=" + ids)
   const decodedText = tok.decode(ids);
   console.log("decoded=" + decodedText);
+
+  const vocabSize = tok.getVocabSize();
+  console.log("vocabSize=" + vocabSize);
+  if (vocabSize !== 32000) {
+    throw Error("Expect Llama to have vocab size 32000");
+  }
 }
 
 async function main() {


### PR DESCRIPTION
We expose `getVocabSize()` and `IdToToken()` to web, subsequently bumping the version to `0.1.3`. Tested in  `web/tests/`.