### PR TITLE
[Rust] Bump HuggingFace tokenizer version

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -8,6 +8,6 @@ crate-type = ["staticlib"]
 
 [dependencies]
 
-tokenizers = { version = "0.13.4", default-features = false, features = ["onig"] }
+tokenizers = { version = "0.19.1", default-features = false, features = ["onig"] }
 serde = { version = "1.0", features = [ "derive" ] }
 serde_json = "1.0"


### PR DESCRIPTION
This PR bumps the HuggingFace tokenizers package version to work with some of the latest models (e.g., Mistral v0.3).