### PR TITLE
Bump CMake minimum to v3.19

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.19...3.30)
 project(tokenizers_cpp C CXX)
 
 set(CMAKE_CXX_STANDARD 17)


### PR DESCRIPTION
Line 144 is calling `add_library(tokenizers_c INTERFACE ${TOKENIZERS_RUST_LIB})`
The signature of add_library(... INTERFACE ...) that accepts sources was added in [CMake v3.19](https://cmake.org/cmake/help/latest/command/add_library.html#interface-with-sources) earlier versions error out if sources are provided to an interface library.

Bump the minimum version to reflect this.  I also specified the upper policy level which helps with deprecation warnings in the future even if compatibility with old versions is maintained.  Details of that can be found here: https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html