### PR TITLE
Add build option for mt/md (#1)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,9 +7,21 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 
 include(FetchContent)
 
+set(TOKENIZERS_CPP_MSVC_RUNTIME_LIBRARY "" CACHE STRING "MSVC runtime library setting (One of MT or MD)")
+
 # update to contain more rust flags
 set(TOKENIZERS_CPP_RUST_FLAGS "")
 set(TOKENIZERS_CPP_CARGO_TARGET "")
+
+if(MSVC)
+  if(TOKENIZERS_CPP_MSVC_RUNTIME_LIBRARY STREQUAL "MT")
+    list(APPEND TOKENIZERS_CPP_RUST_FLAGS -Ctarget-feature=+crt-static)
+  elseif(TOKENIZERS_CPP_MSVC_RUNTIME_LIBRARY STREQUAL "MD")
+    list(APPEND TOKENIZERS_CPP_RUST_FLAGS -Ctarget-feature=-crt-static)
+  elseif(TOKENIZERS_CPP_MSVC_RUNTIME_LIBRARY)
+    message(WARNING "Invalid value for TOKENIZERS_CPP_MSVC_RUNTIME_LIBRARY. Ignoring.")
+  endif()
+endif()
 
 # extra link libraries
 set(TOKENIZERS_CPP_LINK_LIBS "")


### PR DESCRIPTION
We are currently working on an npm package that includes tokenizers-cpp. Since npm packages typically require an MT (static CRT) build on Windows, we encountered a limitation: tokenizers-cpp does not currently provide a way to configure the MSVC runtime option.

This PR introduces a new variable, `TOKENIZERS_CPP_MSVC_RUNTIME_LIBRARY`, which allows external control over the Rust build type, enabling compatibility with the required runtime settings on Windows.

