### PR TITLE
[Rust] Bump huggingface tokenizer to 0.21.1

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -8,6 +8,6 @@ crate-type = ["staticlib"]
 
 [dependencies]
 
-tokenizers = { version = "0.21.0", default-features = false, features = ["onig"] }
+tokenizers = { version = "0.21.1", default-features = false, features = ["onig"] }
 serde = { version = "1.0", features = [ "derive" ] }
 serde_json = "1.0"


### PR DESCRIPTION
This PR bumps the huggignface tokenizer dependency to version 0.21.1 to address the tokenizer issue in some latest models with latest trained tokenizers.