### PR TITLE
[Rust] Bump huggingface tokenizer to 0.21.2

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -8,7 +8,7 @@ crate-type = ["staticlib"]
 
 [dependencies]
 
-tokenizers = { version = "0.21.1", default-features = false, features = ["onig"] }
+tokenizers = { version = "0.21.2", default-features = false, features = ["onig"] }
 serde = { version = "1.0", features = [ "derive" ] }
 serde_json = "1.0"
 ahash = "0.8.12"


### PR DESCRIPTION
This PR bumps the huggignface tokenizer dependency to version 0.21.2 to address the tokenizer build issue in MLC.