### PR TITLE
[Fix] Make raw pointer deref explicit to satisfy dangerous_implicit_autorefs lint

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -218,7 +218,7 @@ extern "C" fn tokenizers_get_decode_str(
 ) {
     unsafe {
         *out_cstr = (*handle).decode_str.as_mut_ptr();
-        *out_len = (*handle).decode_str.len();
+        *out_len = (&(*handle).decode_str).len();
     }
 }
 
@@ -251,7 +251,7 @@ extern "C" fn tokenizers_id_to_token(
         };
 
         *out_cstr = (*handle).id_to_token_result.as_mut_ptr();
-        *out_len = (*handle).id_to_token_result.len();
+        *out_len = (&(*handle).id_to_token_result).len();
     }
 }
 


### PR DESCRIPTION
Explicitly create a reference from `handle` when calling `.len()` to avoid implicit autoref on a raw pointer and comply with Rust's safety requirements.

Prior to this fix, we may run into a build error of
```
   --> src/lib.rs:221:20
    |
221 |         *out_len = (*handle).decode_str.len();
    |                    ^^------^^^^^^^^^^^^^^^^^^
    |                      |
    |                      this raw pointer has type `*mut TokenizerWrapper`
    |
    = note: creating a reference requires the pointer target to be valid and imposes aliasing requirements
note: autoref is being applied to this expression, resulting in: `&std::string::String`
   --> src/lib.rs:221:20
    |
221 |         *out_len = (*handle).decode_str.len();
    |                    ^^^^^^^^^^^^^^^^^^^^
note: method calls to `len` require a reference
   --> /rustc/29483883eed69d5fb4db01964cdf2af4d86e9cb2/library/alloc/src/string.rs:1854:5
    = note: `#[deny(dangerous_implicit_autorefs)]` on by default
help: try using a raw pointer method instead; or if this reference is intentional, make it explicit
    |
221 |         *out_len = (&(*handle).decode_str).len();
    |                    ++                    +
```